### PR TITLE
Replace Futures by Timers

### DIFF
--- a/example/lib/widgets/auto_refresh.dart
+++ b/example/lib/widgets/auto_refresh.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 /// Automatically rebuild [child] widget after the given [duration]
@@ -20,6 +22,8 @@ class _AutoRefreshState extends State<AutoRefresh> {
   int keyValue;
   ValueKey key;
 
+  Timer _timer;
+
   @override
   void initState() {
     super.initState();
@@ -39,7 +43,7 @@ class _AutoRefreshState extends State<AutoRefresh> {
   }
 
   void _recursiveBuild() {
-    Future.delayed(
+    _timer = Timer(
       widget.duration,
       () {
         setState(() {
@@ -49,5 +53,11 @@ class _AutoRefreshState extends State<AutoRefresh> {
         });
       },
     );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
   }
 }

--- a/lib/src/animation_executor.dart
+++ b/lib/src/animation_executor.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'animation_limiter.dart';
 
@@ -25,6 +27,8 @@ class _AnimationExecutorState extends State<AnimationExecutor>
     with SingleTickerProviderStateMixin {
   AnimationController _animationController;
 
+  Timer _timer;
+
   @override
   void initState() {
     super.initState();
@@ -33,7 +37,7 @@ class _AnimationExecutorState extends State<AnimationExecutor>
         AnimationController(duration: widget.duration, vsync: this);
 
     if (AnimationLimiter.shouldRunAnimation(context) ?? true) {
-      Future.delayed(widget.delay, () => _animationController.forward());
+      _timer = Timer(widget.delay,  () => _animationController.forward());
     } else {
       _animationController.value = 1.0;
     }
@@ -49,6 +53,7 @@ class _AnimationExecutorState extends State<AnimationExecutor>
 
   @override
   void dispose() {
+    _timer?.cancel();
     _animationController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
This fix replace the usages of `Future.delay` which produces a non-cancellable action.
Disposing the widget before it is executed will result in an exception.

To circumvent this, we switched to `Timer` that can be cancelled on the widget's dispose method.

Closes #1 