### PR TITLE
Check whether mounted or not before calling setState

### DIFF
--- a/lib/src/animation_limiter.dart
+++ b/lib/src/animation_limiter.dart
@@ -42,6 +42,7 @@ class _AnimationLimiterState extends State<AnimationLimiter> {
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((Duration value) {
+      if(!mounted) return;
       setState(() {
         _shouldRunAnimation = false;
       });


### PR DESCRIPTION
I've occur an exception because setState is called after the widget was disposed, here the error message and stacktrace

```
NoSuchMethodError: The method 'markNeedsBuild' was called on null.
Receiver: null
Tried calling: markNeedsBuild()
```

Stacktrace
```
#0      State.setState (package:flutter/src/widgets/framework.dart:1264)
#1      _AnimationLimiterState.initState.<anonymous closure> (package:flutter_staggered_animations/src/animation_limiter.dart:45)
#2      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1117)
#3      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1063)
#4      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:971)
#5      _rootRun (dart:async/zone.dart:1190)
#6      _CustomZone.run (dart:async/zone.dart:1093)
#7      _CustomZone.runGuarded (dart:async/zone.dart:997)
#8      _invoke (dart:ui/hooks.dart:251)
#9      _drawFrame (dart:ui/hooks.dart:209)
```

I'm adding mounted check on `WidgetsBinding.instance.addPostFrameCallback` because i think its a callback from Async function and need to check whether the widget was disposed or not...

Please consider to merge, because this occur as Unhandled Exception.