### PR TITLE
Migrated null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2021-03-07
+### Added
+- Migrated to null safety
+
 ## [0.1.3] - 2021-03-04
 ### Fixed
 - Fix deprecated call to `ancestorWidgetOfExactType` (method has been removed from Flutter 2.0) [#34](https://github.com/mobiten/flutter_staggered_animations/issues/34) [#29](https://github.com/mobiten/flutter_staggered_animations/issues/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Migrated to null safety
 
+### Fixed
+- Changed `RaisedButton` to `ElevationButton` in example
+
 ## [0.1.3] - 2021-03-04
 ### Fixed
 - Fix deprecated call to `ancestorWidgetOfExactType` (method has been removed from Flutter 2.0) [#34](https://github.com/mobiten/flutter_staggered_animations/issues/34) [#29](https://github.com/mobiten/flutter_staggered_animations/issues/29)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,7 @@ class App extends StatelessWidget {
 }
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({Key key}) : super(key: key);
+  const HomeScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,7 +31,7 @@ class HomeScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               child: const Text('List Card Test'),
               onPressed: () {
                 Navigator.push(
@@ -40,7 +40,7 @@ class HomeScreen extends StatelessWidget {
                 );
               },
             ),
-            RaisedButton(
+            ElevatedButton(
               child: const Text('Grid Card Test'),
               onPressed: () {
                 Navigator.push(
@@ -49,7 +49,7 @@ class HomeScreen extends StatelessWidget {
                 );
               },
             ),
-            RaisedButton(
+            ElevatedButton(
               child: const Text('Column Card Test'),
               onPressed: () {
                 Navigator.push(

--- a/example/lib/screens/card_column_screen.dart
+++ b/example/lib/screens/card_column_screen.dart
@@ -5,7 +5,7 @@ import '../widgets/auto_refresh.dart';
 import '../widgets/empty_card.dart';
 
 class CardColumnScreen extends StatefulWidget {
-  CardColumnScreen({Key key}) : super(key: key);
+  CardColumnScreen({Key? key}) : super(key: key);
 
   @override
   _CardColumnScreenState createState() => _CardColumnScreenState();

--- a/example/lib/screens/card_grid_screen.dart
+++ b/example/lib/screens/card_grid_screen.dart
@@ -5,7 +5,7 @@ import '../widgets/auto_refresh.dart';
 import '../widgets/empty_card.dart';
 
 class CardGridScreen extends StatefulWidget {
-  CardGridScreen({Key key}) : super(key: key);
+  CardGridScreen({Key? key}) : super(key: key);
 
   @override
   _CardGridScreenState createState() => _CardGridScreenState();

--- a/example/lib/screens/card_list_screen.dart
+++ b/example/lib/screens/card_list_screen.dart
@@ -5,7 +5,7 @@ import '../widgets/auto_refresh.dart';
 import '../widgets/empty_card.dart';
 
 class CardListScreen extends StatefulWidget {
-  CardListScreen({Key key}) : super(key: key);
+  CardListScreen({Key? key}) : super(key: key);
 
   @override
   _CardListScreenState createState() => _CardListScreenState();

--- a/example/lib/widgets/auto_refresh.dart
+++ b/example/lib/widgets/auto_refresh.dart
@@ -8,9 +8,9 @@ class AutoRefresh extends StatefulWidget {
   final Widget child;
 
   AutoRefresh({
-    Key key,
-    @required this.duration,
-    @required this.child,
+    Key? key,
+    required this.duration,
+    required this.child,
   })  : assert(duration != null),
         super(key: key);
 
@@ -19,10 +19,10 @@ class AutoRefresh extends StatefulWidget {
 }
 
 class _AutoRefreshState extends State<AutoRefresh> {
-  int keyValue;
-  ValueKey key;
+  int? keyValue;
+  ValueKey? key;
 
-  Timer _timer;
+  Timer? _timer;
 
   @override
   void initState() {
@@ -47,7 +47,7 @@ class _AutoRefreshState extends State<AutoRefresh> {
       widget.duration,
       () {
         setState(() {
-          keyValue = keyValue + 1;
+          keyValue = keyValue! + 1;
           key = ValueKey(keyValue);
           _recursiveBuild();
         });

--- a/example/lib/widgets/auto_refresh.dart
+++ b/example/lib/widgets/auto_refresh.dart
@@ -11,8 +11,7 @@ class AutoRefresh extends StatefulWidget {
     Key? key,
     required this.duration,
     required this.child,
-  })  : assert(duration != null),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   _AutoRefreshState createState() => _AutoRefreshState();

--- a/example/lib/widgets/empty_card.dart
+++ b/example/lib/widgets/empty_card.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 
 class EmptyCard extends StatelessWidget {
-  final double width;
-  final double height;
+  final double? width;
+  final double? height;
 
   const EmptyCard({
-    Key key,
+    Key? key,
     this.width,
     this.height,
   }) : super(key: key);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -61,7 +61,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -73,21 +73,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,55 +99,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,7 +61,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,8 +2,10 @@ name: example
 description: An example app to show the use of Flutter Staggered Animations.
 version: 0.0.1
 
+publish_to: none
+
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/lib/src/animation_configuration.dart
+++ b/lib/src/animation_configuration.dart
@@ -35,11 +35,9 @@ class AnimationConfiguration extends InheritedWidget {
     Key? key,
     this.duration = const Duration(milliseconds: 225),
     required Widget child,
-  })  : position = 0,
+  })   : position = 0,
         delay = Duration.zero,
         columnCount = 1,
-        assert(duration != null),
-        assert(child != null),
         super(key: key, child: child);
 
   /// Configure the children's animation to be staggered.
@@ -67,9 +65,7 @@ class AnimationConfiguration extends InheritedWidget {
     this.duration = const Duration(milliseconds: 225),
     this.delay,
     required Widget child,
-  })  : columnCount = 1,
-        assert(duration != null),
-        assert(child != null),
+  })   : columnCount = 1,
         super(key: key, child: child);
 
   /// Configure the children's animation to be staggered.
@@ -100,10 +96,7 @@ class AnimationConfiguration extends InheritedWidget {
     this.delay,
     required this.columnCount,
     required Widget child,
-  })  : assert(duration != null),
-        assert(columnCount != null && columnCount > 0),
-        assert(child != null),
-        super(key: key, child: child);
+  }) : super(key: key, child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) {

--- a/lib/src/animation_configuration.dart
+++ b/lib/src/animation_configuration.dart
@@ -21,7 +21,7 @@ class AnimationConfiguration extends InheritedWidget {
   final Duration duration;
 
   /// The delay between the beginning of two children's animations.
-  final Duration delay;
+  final Duration? delay;
 
   /// The column count of the grid
   final int columnCount;
@@ -32,9 +32,9 @@ class AnimationConfiguration extends InheritedWidget {
   ///
   /// The [child] argument must not be null.
   const AnimationConfiguration.synchronized({
-    Key key,
+    Key? key,
     this.duration = const Duration(milliseconds: 225),
-    @required Widget child,
+    required Widget child,
   })  : position = 0,
         delay = Duration.zero,
         columnCount = 1,
@@ -62,11 +62,11 @@ class AnimationConfiguration extends InheritedWidget {
   ///
   /// The [child] argument must not be null.
   const AnimationConfiguration.staggeredList({
-    Key key,
-    @required this.position,
+    Key? key,
+    required this.position,
     this.duration = const Duration(milliseconds: 225),
     this.delay,
-    @required Widget child,
+    required Widget child,
   })  : columnCount = 1,
         assert(duration != null),
         assert(child != null),
@@ -94,12 +94,12 @@ class AnimationConfiguration extends InheritedWidget {
   ///
   /// The [child] argument must not be null.
   const AnimationConfiguration.staggeredGrid({
-    Key key,
-    @required this.position,
+    Key? key,
+    required this.position,
     this.duration = const Duration(milliseconds: 225),
     this.delay,
-    @required this.columnCount,
-    @required Widget child,
+    required this.columnCount,
+    required Widget child,
   })  : assert(duration != null),
         assert(columnCount != null && columnCount > 0),
         assert(child != null),
@@ -136,10 +136,10 @@ class AnimationConfiguration extends InheritedWidget {
   /// The [children] argument must not be null.
   /// It corresponds to the children you would normally have passed to the [Column] or [Row].
   static List<Widget> toStaggeredList({
-    Duration duration,
-    Duration delay,
-    @required Widget Function(Widget) childAnimationBuilder,
-    @required List<Widget> children,
+    Duration? duration,
+    Duration? delay,
+    required Widget Function(Widget) childAnimationBuilder,
+    required List<Widget> children,
   }) =>
       children
           .asMap()
@@ -157,7 +157,7 @@ class AnimationConfiguration extends InheritedWidget {
           .values
           .toList();
 
-  static AnimationConfiguration of(BuildContext context) {
+  static AnimationConfiguration? of(BuildContext context) {
     return context.findAncestorWidgetOfExactType<AnimationConfiguration>();
   }
 }

--- a/lib/src/animation_configurator.dart
+++ b/lib/src/animation_configurator.dart
@@ -34,7 +34,7 @@ class AnimationConfigurator extends StatelessWidget {
       );
     }
 
-    final _position = animationConfiguration.position ?? 0;
+    final _position = animationConfiguration.position;
     final _duration = duration ?? animationConfiguration.duration;
     final _delay = delay ?? animationConfiguration.delay;
     final _columnCount = animationConfiguration.columnCount;

--- a/lib/src/animation_configurator.dart
+++ b/lib/src/animation_configurator.dart
@@ -3,15 +3,15 @@ import 'animation_configuration.dart';
 import 'animation_executor.dart';
 
 class AnimationConfigurator extends StatelessWidget {
-  final Duration duration;
-  final Duration delay;
+  final Duration? duration;
+  final Duration? delay;
   final Widget Function(Animation<double>) animatedChildBuilder;
 
   const AnimationConfigurator({
-    Key key,
+    Key? key,
     this.duration,
     this.delay,
-    @required this.animatedChildBuilder,
+    required this.animatedChildBuilder,
   }) : super(key: key);
 
   @override
@@ -48,7 +48,7 @@ class AnimationConfigurator extends StatelessWidget {
   }
 
   Duration stagger(
-      int position, Duration duration, Duration delay, int columnCount) {
+      int position, Duration duration, Duration? delay, int columnCount) {
     var delayInMilliseconds =
         (delay == null ? duration.inMilliseconds ~/ 6 : delay.inMilliseconds);
 

--- a/lib/src/animation_configurator.dart
+++ b/lib/src/animation_configurator.dart
@@ -43,7 +43,7 @@ class AnimationConfigurator extends StatelessWidget {
       duration: _duration,
       delay: stagger(_position, _duration, _delay, _columnCount),
       builder: (context, animationController) =>
-          animatedChildBuilder(animationController),
+          animatedChildBuilder(animationController!),
     );
   }
 

--- a/lib/src/animation_executor.dart
+++ b/lib/src/animation_executor.dart
@@ -4,7 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'animation_limiter.dart';
 
 typedef Builder = Widget Function(
-    BuildContext context, AnimationController animationController);
+    BuildContext context, AnimationController? animationController);
 
 class AnimationExecutor extends StatefulWidget {
   final Duration duration;
@@ -12,10 +12,10 @@ class AnimationExecutor extends StatefulWidget {
   final Builder builder;
 
   const AnimationExecutor({
-    Key key,
-    @required this.duration,
+    Key? key,
+    required this.duration,
     this.delay = Duration.zero,
-    @required this.builder,
+    required this.builder,
   })  : assert(builder != null),
         super(key: key);
 
@@ -25,8 +25,8 @@ class AnimationExecutor extends StatefulWidget {
 
 class _AnimationExecutorState extends State<AnimationExecutor>
     with SingleTickerProviderStateMixin {
-  AnimationController _animationController;
-  Timer _timer;
+  AnimationController? _animationController;
+  Timer? _timer;
 
   @override
   void initState() {
@@ -36,9 +36,9 @@ class _AnimationExecutorState extends State<AnimationExecutor>
         AnimationController(duration: widget.duration, vsync: this);
 
     if (AnimationLimiter.shouldRunAnimation(context) ?? true) {
-      _timer = Timer(widget.delay, () => _animationController.forward());
+      _timer = Timer(widget.delay, () => _animationController!.forward());
     } else {
-      _animationController.value = 1.0;
+      _animationController!.value = 1.0;
     }
   }
 
@@ -46,18 +46,18 @@ class _AnimationExecutorState extends State<AnimationExecutor>
   Widget build(BuildContext context) {
     return AnimatedBuilder(
       builder: _buildAnimation,
-      animation: _animationController,
+      animation: _animationController!,
     );
   }
 
   @override
   void dispose() {
     _timer?.cancel();
-    _animationController.dispose();
+    _animationController!.dispose();
     super.dispose();
   }
 
-  Widget _buildAnimation(BuildContext context, Widget child) {
+  Widget _buildAnimation(BuildContext context, Widget? child) {
     return widget.builder(context, _animationController);
   }
 }

--- a/lib/src/animation_executor.dart
+++ b/lib/src/animation_executor.dart
@@ -16,8 +16,7 @@ class AnimationExecutor extends StatefulWidget {
     required this.duration,
     this.delay = Duration.zero,
     required this.builder,
-  })  : assert(builder != null),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   _AnimationExecutorState createState() => _AnimationExecutorState();

--- a/lib/src/animation_limiter.dart
+++ b/lib/src/animation_limiter.dart
@@ -23,8 +23,7 @@ class AnimationLimiter extends StatefulWidget {
   const AnimationLimiter({
     Key? key,
     required this.child,
-  })  : assert(child != null),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   _AnimationLimiterState createState() => _AnimationLimiterState();
@@ -42,7 +41,7 @@ class _AnimationLimiterState extends State<AnimationLimiter> {
     super.initState();
 
     WidgetsBinding.instance!.addPostFrameCallback((Duration value) {
-      if(!mounted) return;
+      if (!mounted) return;
       setState(() {
         _shouldRunAnimation = false;
       });
@@ -64,8 +63,7 @@ class _AnimationLimiterProvider extends InheritedWidget {
   _AnimationLimiterProvider({
     this.shouldRunAnimation,
     required Widget child,
-  })  : assert(child != null),
-        super(child: child);
+  }) : super(child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) {

--- a/lib/src/animation_limiter.dart
+++ b/lib/src/animation_limiter.dart
@@ -21,15 +21,15 @@ class AnimationLimiter extends StatefulWidget {
   ///
   /// The [child] argument must not be null.
   const AnimationLimiter({
-    Key key,
-    @required this.child,
+    Key? key,
+    required this.child,
   })  : assert(child != null),
         super(key: key);
 
   @override
   _AnimationLimiterState createState() => _AnimationLimiterState();
 
-  static bool shouldRunAnimation(BuildContext context) {
+  static bool? shouldRunAnimation(BuildContext context) {
     return _AnimationLimiterProvider.of(context)?.shouldRunAnimation;
   }
 }
@@ -41,7 +41,7 @@ class _AnimationLimiterState extends State<AnimationLimiter> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((Duration value) {
+    WidgetsBinding.instance!.addPostFrameCallback((Duration value) {
       if(!mounted) return;
       setState(() {
         _shouldRunAnimation = false;
@@ -59,11 +59,11 @@ class _AnimationLimiterState extends State<AnimationLimiter> {
 }
 
 class _AnimationLimiterProvider extends InheritedWidget {
-  final bool shouldRunAnimation;
+  final bool? shouldRunAnimation;
 
   _AnimationLimiterProvider({
     this.shouldRunAnimation,
-    @required Widget child,
+    required Widget child,
   })  : assert(child != null),
         super(child: child);
 
@@ -72,7 +72,7 @@ class _AnimationLimiterProvider extends InheritedWidget {
     return false;
   }
 
-  static _AnimationLimiterProvider of(BuildContext context) {
+  static _AnimationLimiterProvider? of(BuildContext context) {
     return context.findAncestorWidgetOfExactType<_AnimationLimiterProvider>();
   }
 }

--- a/lib/src/fade_in_animation.dart
+++ b/lib/src/fade_in_animation.dart
@@ -4,10 +4,10 @@ import 'animation_configurator.dart';
 /// An animation that fades its child.
 class FadeInAnimation extends StatelessWidget {
   /// The duration of the child animation.
-  final Duration duration;
+  final Duration? duration;
 
   /// The delay between the beginning of two children's animations.
-  final Duration delay;
+  final Duration? delay;
 
   /// The curve of the child animation. Defaults to [Curves.ease].
   final Curve curve;
@@ -19,11 +19,11 @@ class FadeInAnimation extends StatelessWidget {
   ///
   /// The [child] argument must not be null.
   const FadeInAnimation({
-    Key key,
+    Key? key,
     this.duration,
     this.delay,
     this.curve = Curves.ease,
-    @required this.child,
+    required this.child,
   })  : assert(child != null),
         super(key: key);
 

--- a/lib/src/fade_in_animation.dart
+++ b/lib/src/fade_in_animation.dart
@@ -24,8 +24,7 @@ class FadeInAnimation extends StatelessWidget {
     this.delay,
     this.curve = Curves.ease,
     required this.child,
-  })  : assert(child != null),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/flip_animation.dart
+++ b/lib/src/flip_animation.dart
@@ -40,8 +40,7 @@ class FlipAnimation extends StatelessWidget {
     this.curve = Curves.ease,
     this.flipAxis = FlipAxis.x,
     required this.child,
-  })  : assert(child != null),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/flip_animation.dart
+++ b/lib/src/flip_animation.dart
@@ -14,10 +14,10 @@ enum FlipAxis {
 /// An animation that flips its child either vertically or horizontally.
 class FlipAnimation extends StatelessWidget {
   /// The duration of the child animation.
-  final Duration duration;
+  final Duration? duration;
 
   /// The delay between the beginning of two children's animations.
-  final Duration delay;
+  final Duration? delay;
 
   /// The curve of the child animation. Defaults to [Curves.ease].
   final Curve curve;
@@ -34,12 +34,12 @@ class FlipAnimation extends StatelessWidget {
   ///
   /// The [child] argument must not be null.
   const FlipAnimation({
-    Key key,
+    Key? key,
     this.duration,
     this.delay,
     this.curve = Curves.ease,
     this.flipAxis = FlipAxis.x,
-    @required this.child,
+    required this.child,
   })  : assert(child != null),
         super(key: key);
 

--- a/lib/src/scale_animation.dart
+++ b/lib/src/scale_animation.dart
@@ -5,10 +5,10 @@ import 'animation_configurator.dart';
 /// An animation that scales its child.
 class ScaleAnimation extends StatelessWidget {
   /// The duration of the child animation.
-  final Duration duration;
+  final Duration? duration;
 
   /// The delay between the beginning of two children's animations.
-  final Duration delay;
+  final Duration? delay;
 
   /// The curve of the child animation. Defaults to [Curves.ease].
   final Curve curve;
@@ -25,12 +25,12 @@ class ScaleAnimation extends StatelessWidget {
   ///
   /// The [child] argument must not be null.
   const ScaleAnimation({
-    Key key,
+    Key? key,
     this.duration,
     this.delay,
     this.curve = Curves.ease,
     this.scale = 0.0,
-    @required this.child,
+    required this.child,
   })  : assert(child != null),
         assert(scale != null && scale >= 0.0),
         super(key: key);

--- a/lib/src/scale_animation.dart
+++ b/lib/src/scale_animation.dart
@@ -31,8 +31,7 @@ class ScaleAnimation extends StatelessWidget {
     this.curve = Curves.ease,
     this.scale = 0.0,
     required this.child,
-  })  : assert(child != null),
-        assert(scale != null && scale >= 0.0),
+  })   : assert(scale >= 0.0),
         super(key: key);
 
   @override

--- a/lib/src/slide_animation.dart
+++ b/lib/src/slide_animation.dart
@@ -5,10 +5,10 @@ import 'animation_configurator.dart';
 /// An animation that slides its child.
 class SlideAnimation extends StatelessWidget {
   /// The duration of the child animation.
-  final Duration duration;
+  final Duration? duration;
 
   /// The delay between the beginning of two children's animations.
-  final Duration delay;
+  final Duration? delay;
 
   /// The curve of the child animation. Defaults to [Curves.ease].
   final Curve curve;
@@ -30,13 +30,13 @@ class SlideAnimation extends StatelessWidget {
   ///
   /// The [child] argument must not be null.
   const SlideAnimation({
-    Key key,
+    Key? key,
     this.duration,
     this.delay,
     this.curve = Curves.ease,
-    double verticalOffset,
+    double? verticalOffset,
     this.horizontalOffset = 0.0,
-    @required this.child,
+    required this.child,
   })  : verticalOffset = (verticalOffset == null && horizontalOffset == null)
             ? 50.0
             : (verticalOffset ?? 0.0),

--- a/lib/src/slide_animation.dart
+++ b/lib/src/slide_animation.dart
@@ -37,10 +37,7 @@ class SlideAnimation extends StatelessWidget {
     double? verticalOffset,
     this.horizontalOffset = 0.0,
     required this.child,
-  })  : verticalOffset = (verticalOffset == null && horizontalOffset == null)
-            ? 50.0
-            : (verticalOffset ?? 0.0),
-        assert(child != null),
+  })   : verticalOffset = verticalOffset == null ? 50.0 : 0.0,
         super(key: key);
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,28 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -45,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
@@ -67,13 +88,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -85,55 +99,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_staggered_animations
 description: Easily add staggered animations to your ListView, GridView, Column and Row children as shown in Material Design guidelines
-version: 0.1.3
+version: 0.2.0
 homepage: https://github.com/mobiten/flutter_staggered_animations
 repository: https://github.com/mobiten/flutter_staggered_animations
 issue_tracker: https://github.com/mobiten/flutter_staggered_animations/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/mobiten/flutter_staggered_animations
 issue_tracker: https://github.com/mobiten/flutter_staggered_animations/issues
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to `2.12.0+`
* Run `dart migrate` on existing code to remove unsafe nulls (for the package & example)
* Add a new version (`0.2.0`) to the changelog (as [recommended](https://dart.dev/null-safety/migration-guide#package-version))
* Changed `RaisedButton` to `ElevationButton` in example

Please check everything twice!

## Testing
- [x] Tested it manually on a Android emulator 

### Related tickets
Closes #33