### PR TITLE
Support for wrapping the resulting widget in AnimationConfiguration.toStaggeredList() in another widget, also in an Expanded widget

### DIFF
--- a/lib/src/animation_configuration.dart
+++ b/lib/src/animation_configuration.dart
@@ -103,7 +103,7 @@ class AnimationConfiguration extends InheritedWidget {
     return false;
   }
 
-  /// Helper method to apply a staggered animation to the children of a [Column] or [Row].
+    /// Helper method to apply a staggered animation to the children of a [Column] or [Row].
   ///
   /// It maps every child with an index and calls
   /// [AnimationConfiguration.staggeredList] constructor under the hood.
@@ -126,29 +126,56 @@ class AnimationConfiguration extends InheritedWidget {
   /// )
   /// ```
   ///
+  /// The [wrapperBuilder] is a function to wrap the resulting child widget at current index with another widget.
+  ///
+  /// If the returned widget is null, the resulting child widget at current index will be kept in it's place.
+  ///
+  /// This can be used to wrap the resulting child with [Expanded] or [Flex] widget, if needed.
+  ///
   /// The [children] argument must not be null.
   /// It corresponds to the children you would normally have passed to the [Column] or [Row].
+  ///
   static List<Widget> toStaggeredList({
     Duration? duration,
     Duration? delay,
     required Widget Function(Widget) childAnimationBuilder,
     required List<Widget> children,
-  }) =>
-      children
+    Widget? Function(int index, Widget child)? wrapperBuilder,
+  }) {
+    var result = children
+        .asMap()
+        .map<int, Widget>((index, currentChild) {
+          final Widget child = AnimationConfiguration.staggeredList(
+            position: index,
+            duration: duration ?? const Duration(milliseconds: 225),
+            delay: delay,
+            child: childAnimationBuilder(currentChild),
+          );
+          return MapEntry(
+            index,
+            child,
+          );
+        })
+        .values
+        .toList();
+
+    if (wrapperBuilder != null) {
+      result = result
           .asMap()
-          .map((index, widget) {
-            return MapEntry(
+          .map<int, Widget>((index, currentChild) {
+            final resultChild = wrapperBuilder(index, currentChild);
+
+            return MapEntry<int, Widget>(
               index,
-              AnimationConfiguration.staggeredList(
-                position: index,
-                duration: duration ?? const Duration(milliseconds: 225),
-                delay: delay,
-                child: childAnimationBuilder(widget),
-              ),
+              resultChild ?? currentChild,
             );
           })
           .values
           .toList();
+    }
+
+    return result;
+  }
 
   static AnimationConfiguration? of(BuildContext context) {
     return context.findAncestorWidgetOfExactType<AnimationConfiguration>();

--- a/lib/src/animation_configuration.dart
+++ b/lib/src/animation_configuration.dart
@@ -130,7 +130,7 @@ class AnimationConfiguration extends InheritedWidget {
   ///
   /// If the returned widget is null, the resulting child widget at current index will be kept in it's place.
   ///
-  /// This can be used to wrap the resulting child with [Expanded] or [Flex] widget, if needed.
+  /// This can be used to wrap the resulting child with [Expanded] or [Flexible] widget, if needed.
   ///
   /// The [children] argument must not be null.
   /// It corresponds to the children you would normally have passed to the [Column] or [Row].


### PR DESCRIPTION
This adds a new optional parameter `wrapperBuilder` in the helper function `AnimationConfiguration.toStaggeredList()`.

This function can be used to wrap the resulting widget of a child widget, located at any index in the children list, in another widget.

**Declaration**
`Widget? Function(int index, Widget child)? wrapperBuilder`

**Motivation**
This helper function wraps each of the children in a `AnimationConfiguration.staggeredList`. So, you cannot wrap your widget in a `Expanded` or `Flexible` widget, as they needs to be directly placed under a `Flex` widget like `Row` or `Column`. This function gives the opportunity to do that, by letting you wrap the resulting widget wrapped in `AnimationConfiguration.staggeredList`, in another widget.

**Use Cases:**
This function can be used to wrap your widget in `Expanded` or `Flex` widget.

**How to use?**
If you want to wrap the resulting child widget at index 2 in your children list in an `Expanded` widget, you can do that using this function like this:
```
wrapperBuilder: (index, child) {
  if (index == 2) {
    return Expanded(
      child: child,
    );
  }
  return null;
},
```

if `null` is returned, the resulting widget wrapped in `AnimationConfiguration.staggeredList` is used.

The parameter is optional. If not passed, the resulting widgets wrapped in `AnimationConfiguration.staggeredList` are used.